### PR TITLE
Removed deprecated function numpy.asscalar from import list.

### DIFF
--- a/pysid/identification/ivmethod.py
+++ b/pysid/identification/ivmethod.py
@@ -7,7 +7,7 @@ Module for Instrumental Variables methods
 """
 
 #%% imports
-from numpy import arange, array, append, asscalar, copy, count_nonzero, ones,\
+from numpy import arange, array, append, copy, count_nonzero, ones,\
 delete, dot, empty, sum, size, amax, matrix, concatenate, shape, zeros, kron,\
 eye, reshape, convolve, sqrt, where, nonzero, correlate, equal, ndarray, pi, \
 absolute, exp, log, real

--- a/pysid/identification/pemethod.py
+++ b/pysid/identification/pemethod.py
@@ -3,7 +3,7 @@
 """
 
 # Imports
-from numpy import arange, atleast_2d, asarray, array, append, asscalar, copy, count_nonzero, ones,\
+from numpy import arange, atleast_2d, asarray, array, append, copy, count_nonzero, ones,\
 delete, dot, empty, sum, size, amax, matrix, concatenate, shape, zeros, kron,\
 eye, reshape, convolve, sqrt, where, nonzero, correlate, equal, ndarray, pi, \
 absolute, exp, log, real, issubdtype, integer, expand_dims

--- a/pysid/identification/tseries.py
+++ b/pysid/identification/tseries.py
@@ -6,7 +6,7 @@ author: @edumapurunga
 """
 
 # Imports
-from numpy import arange, array, append, asscalar, copy, count_nonzero, ones,\
+from numpy import arange, array, append, copy, count_nonzero, ones,\
 delete, dot, empty, sum, size, amax, matrix, concatenate, shape, zeros, kron,\
 eye, reshape, convolve, sqrt, where, nonzero, correlate, equal, ndarray, pi, \
 absolute, exp, log, real


### PR DESCRIPTION
As described in [numpy.asscalar()](https://numpy.org/doc/1.21/reference/generated/numpy.asscalar.html), the function asscalar has been deprecated, which caused an issue with importing pysid after, for instance, a pip installation using recent numpy versions.

Since the function was only imported and not used, it has been removed from the import list.